### PR TITLE
Don't Coerce the Analyzed object to a string

### DIFF
--- a/build/SqlCodeGuard.Ps1
+++ b/build/SqlCodeGuard.Ps1
@@ -213,7 +213,6 @@ function Read-FileAnalysisResultFromCache {
     [OutputType([string])]
     param (
         [Parameter(Mandatory = $true)]
-        [string]
         $AnalyzedFile
     )
     <#
@@ -252,7 +251,6 @@ function Write-FileAnalysisResultToCache {
     [OutputType([void])]
     param (
         [Parameter(Mandatory = $true)]
-        [string]
         $AnalyzedFile,
 
         [Parameter(Mandatory = $false)]


### PR DESCRIPTION
Coercing the parameter to a string was causing the `$AnalyzedFile.Path` and `$AnalyzedFile.Ticks` to be missing and causing the caching functionality to fail